### PR TITLE
Feat LIC 8 check Implemented

### DIFF
--- a/code/LIC_check.py
+++ b/code/LIC_check.py
@@ -198,3 +198,38 @@ def lic_7_check(data_points, k_pts, length1):
         if distance > length1:
             return True
     return False
+
+def lic_8_check(data_points, a_pts, b_pts, radius1):
+    """Function for checking requirement LIC 8. Returns True
+    if There exists at least one set of three data points separated by exactly A PTS and B PTS
+    consecutive intervening points, respectively, that cannot be contained within or on a circle of
+    radius RADIUS1. The condition is not met when NUMPOINTS < 5
+    """
+    if len(data_points) < 5 or a_pts < 1 or b_pts < 1 or (a_pts + b_pts > len(data_points) -3): 
+        return False
+    
+    for i in range(len(data_points) - a_pts - b_pts - 2):
+        p1 = data_points[i]
+        p2 = data_points[i + a_pts + 1]
+        p3 = data_points[i + a_pts + b_pts + 2]
+        
+        dist1 = sqrt((p2[0] - p1[0])**2 + (p2[1] - p1[1])**2) 
+        dist2 = sqrt((p3[0] - p1[0])**2 + (p3[1] - p1[1])**2) 
+        dist3 = sqrt((p3[0] - p2[0])**2 + (p3[1] - p2[1])**2)
+        
+        if max(dist1, dist2, dist3) > 2*radius1:
+            return True
+        
+        # area of the triangle formed by the three points
+        semi_perimeter = (dist1 + dist2 + dist3) / 2
+        area = sqrt(semi_perimeter * (semi_perimeter - dist1) * (semi_perimeter - dist2) * (semi_perimeter - dist3))
+
+        # colinearity check
+        if area == 0:
+            continue
+
+        circum_radius = (dist1 * dist2 * dist3) / (4 * area)
+        if circum_radius > radius1:
+            return True
+        
+    return False


### PR DESCRIPTION
the function verify if there exists at least one set of three data points separated by exactly A PTS and B PTS consecutive intervening points, respectively, that cannot be contained within or on a circle of radius RADIUS1. The condition is not met when NUMPOINTS < 5

fix #10 