### PR TITLE
Fix Unit tests for LIC 6 check and LIC 8 Check

### DIFF
--- a/code/LIC_check.py
+++ b/code/LIC_check.py
@@ -193,26 +193,27 @@ def lic_6_check(data_points, dist, n_pts):
     the N PTS consecutive points. The condition is not met when NUMPOINTS < 3.
     """
 
-    if len(data_points) < 3 or n_pts > len(data_points) or dist < 0:
+    if (len(data_points) < 3) or (n_pts > len(data_points)) or (dist < 0):
         return False
 
     for i in range(len(data_points) - n_pts + 1):
         p1 = data_points[i]
         p2 = data_points[i + n_pts - 1]
 
-        if p1 == p2:  # If the first and last points are the same
+        if p1 == p2:
             for j in range(i + 1, i + n_pts - 1):
                 p = data_points[j]
                 distance_calculated = calculate_distance(p1, p)
                 if distance_calculated > dist:
                     return True
-        else:  # If the first and last points are different
+                
+        else:
             for j in range(i + 1, i + n_pts - 1):
                 p = data_points[j]
                 distance_calculated = abs((p2[0] - p1[0]) * (p1[1] - p[1]) - (p1[0] - p[0]) * (p2[1] - p1[1])) / sqrt((p2[0] - p1[0])**2 + (p2[1] - p1[1])**2)
                 if distance_calculated > dist:
                     return True
-
+                
     return False
 
 
@@ -244,8 +245,8 @@ def lic_8_check(data_points, a_pts, b_pts, radius1):
 
     for i in range(len(data_points) - a_pts - b_pts - 2):
         p1 = data_points[i]
-        p2 = data_points[i + a_pts + 1]
-        p3 = data_points[i + a_pts + b_pts + 2]
+        p2 = data_points[i + a_pts]
+        p3 = data_points[i + a_pts + b_pts]
 
         dist1 = calculate_distance(p1, p2)
         dist2 = calculate_distance(p3, p1)

--- a/code/LIC_check.py
+++ b/code/LIC_check.py
@@ -3,7 +3,7 @@ from sympy import Eq, solve, symbols
 
 
 def calculate_distance(p1, p2):
-    return sqrt(fabs(p2[0] - p1[0]) ** 2 + fabs(p2[1] - p1[1]) ** 2)
+    return sqrt((p2[0] - p1[0]) ** 2 + (p2[1] - p1[1]) ** 2)
 
 
 def calculate_triangle_area(p1, p2, p3) -> float:

--- a/code/test_LIC_check.py
+++ b/code/test_LIC_check.py
@@ -184,7 +184,7 @@ class TestAllLicChecks:
                 [],
                 1,
                 1,
-                False
+                False,
             ),
 
             # Less data points than q_pts
@@ -192,7 +192,7 @@ class TestAllLicChecks:
                 [(0, 0), (1, 0)],
                 3,
                 1,
-                False
+                False,
             ),
 
             # Test with all points in the same quadrant but quadrants covered <= quads
@@ -200,7 +200,7 @@ class TestAllLicChecks:
                 [(0, 0), (1, 1), (2, 2), (3, 3)],
                 4,
                 1,
-                False
+                False,
             ),
 
             # Test with all points in different quadrants
@@ -208,7 +208,7 @@ class TestAllLicChecks:
                 [(0, 0), (-1, 1), (2, -2), (-3, -3)],
                 4,
                 1,
-                True
+                True,
             ),
 
             # Test with points distributed in two quadrants and quadrants covered > quads
@@ -216,7 +216,7 @@ class TestAllLicChecks:
                 [(1,1), (-1,1), (2,2)],
                 3,
                 1,
-                True
+                True,
             ),
 
             # Test with three point distribuition in three quadrants and quadrants covered > quads
@@ -224,7 +224,7 @@ class TestAllLicChecks:
                 [(1,1), (-1,1), (2,-2)],
                 3,
                 1,
-                True
+                True,
             ),
 
             #Test with all the points in the origin
@@ -232,9 +232,9 @@ class TestAllLicChecks:
                 [(0,0), (0,0), (0,0), (0,0)],
                 4,
                 1,
-                False
+                False,
             ),
-        ]
+        ],
     )
     def test_lic4_check(self, data_points, q_pts, quads, expected):
         assert lic_4_check(data_points, q_pts, quads) == expected
@@ -246,45 +246,45 @@ class TestAllLicChecks:
             # Test no data_points
             (
                 [],
-                False
+                False,
             ),
 
             # Test with a single point
             (
                 [(0, 0)],
-                False
+                False,
             ),
 
             # Test with two consecutive points such that x[j] - x[i] >= 0
             (
                 [(0, 0), (1, 0)],
-                False
-            )
+                False,
+            ),
 
             # Test with two consecutive points such that x[j] - x[i] < 0
             (
                 [(1, 0), (0, 0)],
-                True
+                True,
             ),
 
             # Test with three consecutive points such that x[j] - x[i] >= 0
             (
                 [(0, 0), (1, 0), (2, 0)],
-                False
+                False,
             ),
 
             # Test with three consecutive points with at least one couple such that x[j] - x[i] < 0
             (
                 [(0, 0), (2, 0), (1, 0)],
-                True
+                True,
             ),
 
             # Test with three consecutive points such that x[j] - x[i] < 0
             (
                 [(3, 0), (2, 0), (1, 0)],
-                True
-            )
-        ]
+                True,
+            ),
+        ],
     )
     def test_lic5_check(self, data_points, expected):
         assert lic_5_check(data_points) == expected
@@ -298,7 +298,7 @@ class TestAllLicChecks:
                 [],
                 1,
                 3,
-                False
+                False,
             ),
 
             # Test with less points than n_pts
@@ -306,7 +306,7 @@ class TestAllLicChecks:
                 [(0, 0), (1, 0)],
                 1,
                 3,
-                False
+                False,
             ),
 
             # Test with three points such that distance bewteen them is more than dist
@@ -314,7 +314,7 @@ class TestAllLicChecks:
                 [(0,0), (1, 2), (2, 0)],
                 1,
                 3,
-                True
+                True,
             ),
 
             # Test with three points such that distance bewteen them is less than dist
@@ -322,7 +322,7 @@ class TestAllLicChecks:
                 [(0,0), (1, 1), (2, 0)],
                 2,
                 3,
-                False
+                False,
             ),
 
             # Test with two coicident points and one point at a distance more than dist
@@ -330,7 +330,7 @@ class TestAllLicChecks:
                 [(0,0), (0,0), (2, 0)],
                 1,
                 3,
-                True
+                True,
             ),
 
             # Test with two coicident points and one point at a distance less than dist
@@ -338,7 +338,7 @@ class TestAllLicChecks:
                 [(0,0), (0,0), (1, 0)],
                 2,
                 3,
-                False
+                False,
             ),
 
             # Test with three points at the same distance
@@ -346,7 +346,7 @@ class TestAllLicChecks:
                 [(0,0), (1, 0), (2, 0)],
                 1,
                 3,
-                False
+                False,
             ),
 
             # Test with multiple sets of points, one satisfies the condition
@@ -354,13 +354,102 @@ class TestAllLicChecks:
                 [(0, 0), (1, 1), (2, 0), (3, 3)],
                 1,
                 3,
-                True
+                True,
             ),
-        ]
+        ],
     )
     def test_lic6_check(self, data_points, dist, n_pts, expected):
         assert lic_6_check(data_points, dist, n_pts) == expected
 
+
+    @pytest.mark.parametrize(
+       "data_points, a_pts, b_pts, radius1, expected",
+        [
+            # Test no data_points
+            (
+                [],
+                1,
+                1,
+                1,
+                False,
+            ),
+
+            # Test with less then 5 points
+            (
+                [(0,0), (1,1), (2,2), (3,3)],
+                1,
+                1,
+                1,
+                False,
+            ),
+
+            # Test with a_pts < 1
+            (
+                [(0,0), (1,1), (2,2), (3,3), (4,4)],
+                0,
+                1,
+                1,
+                False,
+            ),
+
+            # Test with b_pts < 1
+            (
+                [(0,0), (1,1), (2,2), (3,3), (4,4)],
+                1,
+                0,
+                1,
+                False,
+            ),
+
+            # Test with a_pts + b_pts > numpoints - 3
+            (
+                [(0,0), (1,1), (2,2), (3,3), (4,4)],
+                2,
+                2,
+                1,
+                False,
+            ),
+
+            # Test with three points in a circle with radius1
+            (
+                [(0,0), (1,0), (2,0), (1,1), (0,2)],
+                1,
+                1,
+                3,
+                False,
+            ),
+
+            # Test with three points NOT in a circle with radius1
+            (
+                [(0,0), (1,0), (2,0), (1,1), (0,6)],
+                1,
+                1,
+                1,
+                True,
+            ),
+
+            # Test with collinear points
+            (
+                [(0,0), (1,0), (2,0), (3,0), (4,0)],
+                1,
+                1,
+                1,
+                False,
+            ),
+
+            # Test with all points in the origin
+            (
+                [(0,0), (0,0), (0,0), (0,0), (0,0)],
+                1,
+                1,
+                1,
+                False,
+            ),
+        ],
+    )
+    def test_lic7_check(self, data_points, a_pts, b_pts, radius1, expected):
+        assert lic_7_check(data_points, a_pts, b_pts, radius1) == expected
+        
 
     @pytest.mark.parametrize(
         "data_points, numpoints, e_pts, f_pts, area1, expected",

--- a/code/test_LIC_check.py
+++ b/code/test_LIC_check.py
@@ -464,7 +464,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 40,
-                False
+                False,
             ),
 
             # Test NUMPOINTS < 5
@@ -474,7 +474,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 40,
-                False
+                False,
 
             ),
 
@@ -485,7 +485,7 @@ class TestAllLicChecks:
                 0,
                 1,
                 40,
-                False
+                False,
             ),
 
             # Test F_PTS < 1
@@ -495,7 +495,7 @@ class TestAllLicChecks:
                 1,
                 0,
                 40,
-                False
+                False,
             ),
 
             # E PTS+F PTS > NUMPOINTS−3
@@ -505,7 +505,7 @@ class TestAllLicChecks:
                 1,
                 2,
                 40,
-                False
+                False,
             ),
 
             # Test with all points the same
@@ -515,7 +515,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 50,
-                False
+                False,
             ),
 
             # Test with all on the same line
@@ -525,7 +525,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 1,
-                False
+                False,
             ),
 
             # Test no points larger than AREA1, area of [P0, P2, P4] (=50) < AREA1 (=60)
@@ -535,7 +535,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 60,
-                False
+                False,
             ),
 
             # Test Area of [P0, P2, P4] (=25) == AREA1 (=50)
@@ -545,7 +545,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 50,
-                False
+                False,
             ),
 
             # Test Area of [P0, P2, P4] (=25) > AREA1 (=40)
@@ -555,7 +555,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 40,
-                True
+                True,
             ),
 
             # Test with 6 elements, [P0, P2, P4] are offset to [P1, P3, P5], doesn't start with the element in sequence
@@ -565,7 +565,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 40,
-                True
+                True,
             ),
 
             # Test with 7 elements, doesn't end with the element in sequence
@@ -575,7 +575,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 40,
-                True
+                True,
             ),
 
             # Test with more than minimal offset e_pts
@@ -585,7 +585,7 @@ class TestAllLicChecks:
                 2,
                 1,
                 40,
-                True
+                True,
             ),
 
             # Test with more than minimal offset f_pts
@@ -595,7 +595,7 @@ class TestAllLicChecks:
                 1,
                 2,
                 40,
-                True
+                True,
             ),
 
             # Test with more than minimal offset both e_pts and f_pts
@@ -605,7 +605,7 @@ class TestAllLicChecks:
                 2,
                 2,
                 40,
-                True
+                True,
             ),
 
             # Test with more point combinations being larger than the area
@@ -615,9 +615,9 @@ class TestAllLicChecks:
                 2,
                 2,
                 0.1,
-                True
+                True,
             ),
-        ]
+        ],
     )
     def test_lic10_check(self, data_points, numpoints, e_pts, f_pts, area1, expected):
         assert lic_10_check(data_points, numpoints, e_pts, f_pts, area1) == expected
@@ -630,7 +630,7 @@ class TestAllLicChecks:
                 [],
                 0,
                 1,
-                False
+                False,
             ),
 
             # Test NUMPOINTS < 3
@@ -638,7 +638,7 @@ class TestAllLicChecks:
                 [(1, 0), (0, 0)],
                 2,
                 1,
-                False
+                False,
             ),
 
             # Test G_PTS < 1
@@ -646,7 +646,7 @@ class TestAllLicChecks:
                 [(1, 0), (0, 0), (0, 1)],
                 3,
                 0,
-                False
+                False,
             ),
 
             # Test G_PTS > NUMPOINTS−2
@@ -654,7 +654,7 @@ class TestAllLicChecks:
                 [(1, 0), (0, 0), (0, 1)],
                 3,
                 2,
-                False
+                False,
             ),
 
             # Test with all points the same
@@ -662,7 +662,7 @@ class TestAllLicChecks:
                 [(0, 0), (0, 0), (0, 0)],
                 3,
                 1,
-                False
+                False,
             ),
 
             # Test x_1 < x_2
@@ -670,7 +670,7 @@ class TestAllLicChecks:
                 [(0, 1), (0, 0), (1, 0)],
                 3,
                 1,
-                False
+                False,
             ),
 
             # Test x_1 == x_2
@@ -678,7 +678,7 @@ class TestAllLicChecks:
                 [(0, 1), (0, 0), (0, 2)],
                 3,
                 1,
-                False
+                False,
             ),
 
             # Test x_1 > x_2
@@ -686,7 +686,7 @@ class TestAllLicChecks:
                 [(1, 0), (0, 0), (0, 1)],
                 3,
                 1,
-                True
+                True,
             ),
 
             # Test with extra element in the beginning
@@ -694,7 +694,7 @@ class TestAllLicChecks:
                 [(-2, 2), (1, 0), (0, 0), (0, 1)],
                 4,
                 1,
-                True
+                True,
             ),
 
             # Test with extra element in at the end
@@ -702,7 +702,7 @@ class TestAllLicChecks:
                 [(-2, 2), (1, 0), (0, 0), (0, 1), (3, 3)],
                 5,
                 1,
-                True
+                True,
             ),
 
             # Test with non-minimal offset
@@ -710,16 +710,16 @@ class TestAllLicChecks:
                 [(-2, 2), (1, 0), (0, 0), (3, 3), (0, 1), (4, 4)],
                 6,
                 2,
-                True
+                True,
             ),
             # Test with multiple right answers
             (
                 [(-2, 2), (1, 0), (5, 5), (3, 3), (1, 1), (4, 4), (2, 2)],
                 7,
                 2,
-                True
+                True,
             ),
-        ]
+        ],
     )
     def test_lic11_check(self, data_points, numpoints, g_pts, expected):
         assert lic_11_check(data_points, numpoints, g_pts) == expected
@@ -738,7 +738,7 @@ class TestAllLicChecks:
                 1,
                 0,
                 1,
-                False
+                False,
             ),
 
             # Test NUMPOINTS < 3
@@ -748,7 +748,7 @@ class TestAllLicChecks:
                 1,
                 0,
                 1,
-                False
+                False,
             ),
 
             # Test K_PTS < 1 (assuming it should be that K_PTS >= 1, as with LIC 12)
@@ -758,7 +758,7 @@ class TestAllLicChecks:
                 0,
                 0,
                 2,
-                False
+                False,
             ),
 
             # Test K_PTS > NUMPOINTS−2 (assuming, same as with LIC 11)
@@ -768,7 +768,7 @@ class TestAllLicChecks:
                 2,
                 0,
                 2,
-                False
+                False,
             ),
 
             # Test with all points the same
@@ -778,7 +778,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 2,
-                False
+                False,
             ),
 
             # Test with length1 < 0
@@ -788,7 +788,7 @@ class TestAllLicChecks:
                 1,
                 -1,
                 2,
-                False
+                False,
             ),
 
             # Test with length2 < 0
@@ -798,7 +798,7 @@ class TestAllLicChecks:
                 1,
                 0,
                 -1,
-                False
+                False,
             ),
 
             # Test with same dist, length1 (=0) < calc dist (=1), but calc dist (=1) > length2 (=0)
@@ -808,7 +808,7 @@ class TestAllLicChecks:
                 1,
                 0,
                 0,
-                False
+                False,
             ),
 
             # Test with same dist, length2 (=0) > calc dist (=1), but calc dist (=1) < length1 (=2)
@@ -818,7 +818,7 @@ class TestAllLicChecks:
                 1,
                 2,
                 2,
-                False
+                False,
             ),
 
             # Test with same dist, length1 (=0) < calc dist (=1) < length2 (=2)
@@ -828,7 +828,7 @@ class TestAllLicChecks:
                 1,
                 0,
                 2,
-                True
+                True,
             ),
 
             # Test with 2 dist, dist1 (=1) < length2 (=5), length1 (=3) < dist2 (=4) < length2 (=5)
@@ -838,7 +838,7 @@ class TestAllLicChecks:
                 1,
                 3,
                 5,
-                True
+                True,
             ),
 
             # Test with 2 dist, dist1 (=1) < length2 (=5), length1 (=3) < dist2 (=10)
@@ -848,7 +848,7 @@ class TestAllLicChecks:
                 1,
                 3,
                 5,
-                True
+                True,
             ),
 
             # Test with 2 dist, dist1 (=1) < length2 (=2), length1 (=3) < dist2 (=4)
@@ -858,7 +858,7 @@ class TestAllLicChecks:
                 1,
                 3,
                 2,
-                True
+                True,
             ),
 
             # Test with 2 dist, dist1 (=4) > length1 (=3), length2 (=2) > dist2 (=1)
@@ -868,7 +868,7 @@ class TestAllLicChecks:
                 1,
                 3,
                 2,
-                True
+                True,
             ),
 
             # Test with extra distance
@@ -878,7 +878,7 @@ class TestAllLicChecks:
                 1,
                 3,
                 5,
-                True
+                True,
             ),
 
             # Test non-minimal offset
@@ -888,9 +888,9 @@ class TestAllLicChecks:
                 2,
                 3,
                 5,
-                True
+                True,
             ),
-        ]
+        ],
     )
     def test_lic12_check(self, data_points, numpoints, k_pts, length1, length2, expected):
         assert lic_12_check(data_points, numpoints, k_pts, length1, length2) == expected

--- a/code/test_LIC_check.py
+++ b/code/test_LIC_check.py
@@ -239,6 +239,56 @@ class TestAllLicChecks:
     def test_lic4_check(self, data_points, q_pts, quads, expected):
         assert lic_4_check(data_points, q_pts, quads) == expected
 
+    
+    @pytest.mark.parametrize(
+        "data_points, expected",
+        [
+            # Test no data_points
+            (
+                [],
+                False
+            ),
+
+            # Test with a single point
+            (
+                [(0, 0)],
+                False
+            ),
+
+            # Test with two consecutive points such that x[j] - x[i] >= 0
+            (
+                [(0, 0), (1, 0)],
+                False
+            )
+
+            # Test with two consecutive points such that x[j] - x[i] < 0
+            (
+                [(1, 0), (0, 0)],
+                True
+            ),
+
+            # Test with three consecutive points such that x[j] - x[i] >= 0
+            (
+                [(0, 0), (1, 0), (2, 0)],
+                False
+            ),
+
+            # Test with three consecutive points with at least one couple such that x[j] - x[i] < 0
+            (
+                [(0, 0), (2, 0), (1, 0)],
+                True
+            ),
+
+            # Test with three consecutive points such that x[j] - x[i] < 0
+            (
+                [(3, 0), (2, 0), (1, 0)],
+                True
+            )
+        ]
+    )
+    def test_lic5_check(self, data_points, expected):
+        assert lic_5_check(data_points) == expected
+    
     @pytest.mark.parametrize(
         "data_points, numpoints, e_pts, f_pts, area1, expected",
         [

--- a/code/test_LIC_check.py
+++ b/code/test_LIC_check.py
@@ -484,7 +484,7 @@ class TestAllLicChecks:
                 1,
                 1,
                 1,
-                False,
+                True,
             ),
 
             # Test with all points in the origin

--- a/code/test_LIC_check.py
+++ b/code/test_LIC_check.py
@@ -380,7 +380,7 @@ class TestAllLicChecks:
                 [(0,0), (0,0), (2, 0)],
                 1,
                 3,
-                True,
+                False,
             ),
 
             # Test with two coicident points and one point at a distance less than dist

--- a/code/test_LIC_check.py
+++ b/code/test_LIC_check.py
@@ -289,6 +289,79 @@ class TestAllLicChecks:
     def test_lic5_check(self, data_points, expected):
         assert lic_5_check(data_points) == expected
     
+
+    @pytest.mark.parametrize(
+        "data_points, dist, n_pts, expected",
+        [
+            # Test no data_points
+            (
+                [],
+                1,
+                3,
+                False
+            ),
+
+            # Test with less points than n_pts
+            (
+                [(0, 0), (1, 0)],
+                1,
+                3,
+                False
+            ),
+
+            # Test with three points such that distance bewteen them is more than dist
+            (
+                [(0,0), (1, 2), (2, 0)],
+                1,
+                3,
+                True
+            ),
+
+            # Test with three points such that distance bewteen them is less than dist
+            (
+                [(0,0), (1, 1), (2, 0)],
+                2,
+                3,
+                False
+            ),
+
+            # Test with two coicident points and one point at a distance more than dist
+            (
+                [(0,0), (0,0), (2, 0)],
+                1,
+                3,
+                True
+            ),
+
+            # Test with two coicident points and one point at a distance less than dist
+            (
+                [(0,0), (0,0), (1, 0)],
+                2,
+                3,
+                False
+            ),
+
+            # Test with three points at the same distance
+            (
+                [(0,0), (1, 0), (2, 0)],
+                1,
+                3,
+                False
+            ),
+
+            # Test with multiple sets of points, one satisfies the condition
+            (
+                [(0, 0), (1, 1), (2, 0), (3, 3)],
+                1,
+                3,
+                True
+            ),
+        ]
+    )
+    def test_lic6_check(self, data_points, dist, n_pts, expected):
+        assert lic_6_check(data_points, dist, n_pts) == expected
+
+
     @pytest.mark.parametrize(
         "data_points, numpoints, e_pts, f_pts, area1, expected",
         [


### PR DESCRIPTION
- Fixed the error in the LIC 6 Unit Test dedicated to the test with two coincidence points and one point at a distance more than dist
- Fixed the error in the LIC 8 Unit Test dedicated to the test of collinear points